### PR TITLE
Remove mentions of Solid.js from UI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 $ npm install # or pnpm install or yarn install
 ```
 
-### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
-
 ## Available Scripts
 
 In the project directory, you can run:

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <title>Solid App</title>
+    <title>IEEE 754 Floating Point Simulator</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -241,7 +241,7 @@ const App: Component = () => {
 
   return (
     <div class="app-container">
-      <h1>IEEE 754 浮動小数点数シミュレータ (Solid.js Version)</h1>
+      <h1>IEEE 754 浮動小数点数シミュレータ</h1>
       <NumberInput
         value={decimalStringInput}
         onInput={handleDecimalChange}


### PR DESCRIPTION
This commit removes references to "Solid.js" from the application's title, the main heading displayed on the page, and the README.md file.

The issue requested that "Solid.js" should not be displayed on the screen or in the title.