### PR TITLE
feat: Color code bit buttons based on value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "~5.8.3",
         "vite": "^6.3.5",
         "vite-plugin-solid": "^2.11.6",
-        "vitest": "^3.2.0"
+        "vitest": "^3.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1284,14 +1284,14 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
-      "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
+      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1300,12 +1300,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.0.tgz",
-      "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
+      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "3.2.0",
+        "@vitest/spy": "3.2.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1326,9 +1326,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
-      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
+      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -1338,12 +1338,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.0.tgz",
-      "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
+      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.2.0",
+        "@vitest/utils": "3.2.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1351,12 +1351,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.0.tgz",
-      "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
+      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1365,9 +1365,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
-      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
+      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -1377,12 +1377,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.0.tgz",
-      "integrity": "sha512-cYFZZSl1usgzsHoGF66GHfYXlEwc06ggapS1TaSLMKCzhTPWBPI9b/t1RvKIsLSjdKUakpSPf33jQMvRjMvvlQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.1.tgz",
+      "integrity": "sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.2.0",
+        "@vitest/utils": "3.2.1",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -1394,16 +1394,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.0"
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
-      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.0.tgz",
-      "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
+      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -2739,19 +2739,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.0.tgz",
-      "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
+      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.0",
-        "@vitest/mocker": "3.2.0",
-        "@vitest/pretty-format": "^3.2.0",
-        "@vitest/runner": "3.2.0",
-        "@vitest/snapshot": "3.2.0",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/expect": "3.2.1",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/pretty-format": "^3.2.1",
+        "@vitest/runner": "3.2.1",
+        "@vitest/snapshot": "3.2.1",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -2765,7 +2765,7 @@
         "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.0",
+        "vite-node": "3.2.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2781,8 +2781,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.0",
-        "@vitest/ui": "3.2.0",
+        "@vitest/browser": "3.2.1",
+        "@vitest/ui": "3.2.1",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-solid": "^2.11.6",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.1"
   }
 }

--- a/src/components/BitRepresentationInput.test.tsx
+++ b/src/components/BitRepresentationInput.test.tsx
@@ -34,6 +34,11 @@ describe('BitRepresentationInput component', () => {
 
     const signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('1');
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
+
+    setSign('0');
+    expect(signBit?.textContent).toBe('0');
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
   });
 
   it('should call onSignBitClick when sign bit is clicked', () => {
@@ -55,7 +60,9 @@ describe('BitRepresentationInput component', () => {
     const exponentBits = document.querySelectorAll('.clickable-bit.exponent-bit-span');
     expect(exponentBits).toHaveLength(11);
     expect(exponentBits[0].textContent).toBe('1');
+    expect(exponentBits[0].classList.contains('bit-one')).toBe(true);
     expect(exponentBits[1].textContent).toBe('0');
+    expect(exponentBits[1].classList.contains('bit-zero')).toBe(true);
   });
 
   it('should call onExponentBitClick with correct index', () => {
@@ -80,8 +87,11 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
     expect(significandBits).toHaveLength(52);
     expect(significandBits[0].textContent).toBe('1');
+    expect(significandBits[0].classList.contains('bit-one')).toBe(true);
     expect(significandBits[1].textContent).toBe('0');
+    expect(significandBits[1].classList.contains('bit-zero')).toBe(true);
     expect(significandBits[2].textContent).toBe('1');
+    expect(significandBits[2].classList.contains('bit-one')).toBe(true);
   });
 
   it('should call onSignificandBitClick with correct index', () => {
@@ -108,14 +118,20 @@ describe('BitRepresentationInput component', () => {
 
     let signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('0');
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
 
     setSign('1');
+    // Re-query after state change if component re-renders, or ensure reactivity handles class update
     signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('1');
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
 
     setExponent('10000000000');
     const exponentBits = document.querySelectorAll('.clickable-bit.exponent-bit-span');
     expect(exponentBits[0].textContent).toBe('1');
+    expect(exponentBits[0].classList.contains('bit-one')).toBe(true);
+    expect(exponentBits[1].textContent).toBe('0');
+    expect(exponentBits[1].classList.contains('bit-zero')).toBe(true);
   });
 
   it('should handle edge case with all zeros', () => {
@@ -133,8 +149,9 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
 
     expect(signBit?.textContent).toBe('0');
-    expect(Array.from(exponentBits).every(bit => bit.textContent === '0')).toBe(true);
-    expect(Array.from(significandBits).every(bit => bit.textContent === '0')).toBe(true);
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
+    expect(Array.from(exponentBits).every(bit => bit.textContent === '0' && bit.classList.contains('bit-zero'))).toBe(true);
+    expect(Array.from(significandBits).every(bit => bit.textContent === '0' && bit.classList.contains('bit-zero'))).toBe(true);
   });
 
   it('should handle edge case with all ones', () => {
@@ -152,7 +169,8 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
 
     expect(signBit?.textContent).toBe('1');
-    expect(Array.from(exponentBits).every(bit => bit.textContent === '1')).toBe(true);
-    expect(Array.from(significandBits).every(bit => bit.textContent === '1')).toBe(true);
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
+    expect(Array.from(exponentBits).every(bit => bit.textContent === '1' && bit.classList.contains('bit-one'))).toBe(true);
+    expect(Array.from(significandBits).every(bit => bit.textContent === '1' && bit.classList.contains('bit-one'))).toBe(true);
   });
 });

--- a/src/components/BitRepresentationInput.tsx
+++ b/src/components/BitRepresentationInput.tsx
@@ -19,7 +19,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
         <div class="bit-group sign-bit">
           <label>符号 (1ビット):</label>
           {/* No scroll container needed for a single bit */}
-          <span class="clickable-bit sign-bit-span" onClick={() => props.onSignBitClick()}>
+          <span class={`clickable-bit sign-bit-span ${props.sign() === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onSignBitClick()}>
             {props.sign()}
           </span>
         </div>
@@ -27,7 +27,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
           <label>指数 ({EXPONENT_BITS}ビット):</label>
           <div class="bits-scroll-container">
             {props.exponent().split('').map((bit, index) => (
-              <span class="clickable-bit exponent-bit-span" onClick={() => props.onExponentBitClick(index)}>
+              <span class={`clickable-bit exponent-bit-span ${bit === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onExponentBitClick(index)}>
                 {bit}
               </span>
             ))}
@@ -37,7 +37,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
           <label>仮数 ({SIGNIFICAND_BITS}ビット):</label>
           <div class="bits-scroll-container">
             {props.significand().split('').map((bit, index) => (
-              <span class="clickable-bit significand-bit-span" onClick={() => props.onSignificandBitClick(index)}>
+              <span class={`clickable-bit significand-bit-span ${bit === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onSignificandBitClick(index)}>
                 {bit}
               </span>
             ))}

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -122,6 +122,14 @@ input[type='text']:focus {
   border-color: #aaa;
 }
 
+.bit-zero {
+  background-color: #e0e0e0;
+}
+
+.bit-one {
+  background-color: #a0d3ff;
+}
+
 /* Specific bit spans can inherit from clickable-bit. Add specific styles if needed. */
 .sign-bit-span {}
 


### PR DESCRIPTION
Implemented different background colors for bit toggle buttons to visually distinguish between '0' and '1' states, enhancing readability.

- Added `.bit-zero` and `.bit-one` CSS classes in `src/components/components.css` with distinct background colors.
- Modified `src/components/BitRepresentationInput.tsx` to dynamically apply these classes to the sign, exponent, and significand bit elements based on their respective values.
- Updated tests in `src/components/BitRepresentationInput.test.tsx` to assert the correct application of these new CSS classes and ensure existing functionality remains intact. All tests pass.