### PR TITLE
Refactor: Move exponent and mantissa sliders closer to bit representa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,12 @@
         "@solidjs/testing-library": "^0.8.10",
         "@testing-library/jest-dom": "^6.6.3",
         "@vitest/ui": "^3.2.0",
+        "canvas": "^3.1.0",
         "jsdom": "^26.1.0",
         "typescript": "~5.8.3",
         "vite": "^6.3.5",
         "vite-plugin-solid": "^2.11.6",
-        "vitest": "^3.2.0"
+        "vitest": "^3.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1284,14 +1285,14 @@
       "dev": true
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.0.tgz",
-      "integrity": "sha512-0v4YVbhDKX3SKoy0PHWXpKhj44w+3zZkIoVES9Ex2pq+u6+Bijijbi2ua5kE+h3qT6LBWFTNZSCOEU37H8Y5sA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.1.tgz",
+      "integrity": "sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1300,12 +1301,12 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.0.tgz",
-      "integrity": "sha512-HFcW0lAMx3eN9vQqis63H0Pscv0QcVMo1Kv8BNysZbxcmHu3ZUYv59DS6BGYiGQ8F5lUkmsfMMlPm4DJFJdf/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.1.tgz",
+      "integrity": "sha512-OXxMJnx1lkB+Vl65Re5BrsZEHc90s5NMjD23ZQ9NlU7f7nZiETGoX4NeKZSmsKjseuMq2uOYXdLOeoM0pJU+qw==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "3.2.0",
+        "@vitest/spy": "3.2.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1326,9 +1327,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.0.tgz",
-      "integrity": "sha512-gUUhaUmPBHFkrqnOokmfMGRBMHhgpICud9nrz/xpNV3/4OXCn35oG+Pl8rYYsKaTNd/FAIrqRHnwpDpmYxCYZw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.1.tgz",
+      "integrity": "sha512-xBh1X2GPlOGBupp6E1RcUQWIxw0w/hRLd3XyBS6H+dMdKTAqHDNsIR2AnJwPA3yYe9DFy3VUKTe3VRTrAiQ01g==",
       "dev": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
@@ -1338,12 +1339,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.0.tgz",
-      "integrity": "sha512-bXdmnHxuB7fXJdh+8vvnlwi/m1zvu+I06i1dICVcDQFhyV4iKw2RExC/acavtDn93m/dRuawUObKsrNE1gJacA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.1.tgz",
+      "integrity": "sha512-kygXhNTu/wkMYbwYpS3z/9tBe0O8qpdBuC3dD/AW9sWa0LE/DAZEjnHtWA9sIad7lpD4nFW1yQ+zN7mEKNH3yA==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.2.0",
+        "@vitest/utils": "3.2.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1351,12 +1352,12 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.0.tgz",
-      "integrity": "sha512-z7P/EneBRMe7hdvWhcHoXjhA6at0Q4ipcoZo6SqgxLyQQ8KSMMCmvw1cSt7FHib3ozt0wnRHc37ivuUMbxzG/A==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.1.tgz",
+      "integrity": "sha512-5xko/ZpW2Yc65NVK9Gpfg2y4BFvcF+At7yRT5AHUpTg9JvZ4xZoyuRY4ASlmNcBZjMslV08VRLDrBOmUe2YX3g==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1365,9 +1366,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.0.tgz",
-      "integrity": "sha512-s3+TkCNUIEOX99S0JwNDfsHRaZDDZZR/n8F0mop0PmsEbQGKZikCGpTGZ6JRiHuONKew3Fb5//EPwCP+pUX9cw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.1.tgz",
+      "integrity": "sha512-Nbfib34Z2rfcJGSetMxjDCznn4pCYPZOtQYox2kzebIJcgH75yheIKd5QYSFmR8DIZf2M8fwOm66qSDIfRFFfQ==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
@@ -1377,12 +1378,12 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.0.tgz",
-      "integrity": "sha512-cYFZZSl1usgzsHoGF66GHfYXlEwc06ggapS1TaSLMKCzhTPWBPI9b/t1RvKIsLSjdKUakpSPf33jQMvRjMvvlQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.1.tgz",
+      "integrity": "sha512-xT93aOcPn2wn8vvw4T6rZAK9WjGEHdYrEjN3OJ1zcDpl2UInxvcD9fYI10nmPAERNEK6jUVcSCIPAIfNuaRX6Q==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "3.2.0",
+        "@vitest/utils": "3.2.1",
         "fflate": "^0.8.2",
         "flatted": "^3.3.3",
         "pathe": "^2.0.3",
@@ -1394,16 +1395,16 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "3.2.0"
+        "vitest": "3.2.1"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.0.tgz",
-      "integrity": "sha512-gXXOe7Fj6toCsZKVQouTRLJftJwmvbhH5lKOBR6rlP950zUq9AitTUjnFoXS/CqjBC2aoejAztLPzzuva++XBw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.1.tgz",
+      "integrity": "sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==",
       "dev": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.2.0",
+        "@vitest/pretty-format": "3.2.1",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -1503,6 +1504,37 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -1535,6 +1567,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1563,6 +1619,20 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvas": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.1.0.tgz",
+      "integrity": "sha512-tTj3CqqukVJ9NgSahykNwtGda7V33VLObwrHfzT0vqJXu7J4d4C/7kQQW3fOEGDfZZoILPut5H00gOjyttPGyg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
     },
     "node_modules/chai": {
       "version": "5.2.0",
@@ -1604,6 +1674,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1689,6 +1765,21 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1698,6 +1789,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -1705,6 +1805,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -1718,6 +1827,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.162.tgz",
       "integrity": "sha512-hQA+Zb5QQwoSaXJWEAGEw1zhk//O7qDzib05Z4qTqZfNju/FAkrm5ZInp0JbTp4Z18A6bilopdZWEYrFSsfllA==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.0",
@@ -1795,6 +1913,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
@@ -1830,6 +1957,12 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1852,6 +1985,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true
     },
     "node_modules/globals": {
       "version": "11.12.0",
@@ -1927,6 +2066,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1936,6 +2095,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -2079,6 +2250,18 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2088,6 +2271,21 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -2122,6 +2320,42 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -2133,6 +2367,15 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
       "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
       "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -2207,6 +2450,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "dev": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -2233,6 +2502,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2242,11 +2521,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -2307,6 +2615,26 @@
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
       "dev": true
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2358,6 +2686,51 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sirv": {
       "version": "3.0.1",
@@ -2418,6 +2791,15 @@
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "dev": true
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -2429,6 +2811,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/supports-color": {
@@ -2448,6 +2839,34 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2555,6 +2974,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -2597,6 +3028,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/validate-html-nesting": {
       "version": "1.2.2",
@@ -2679,9 +3116,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.0.tgz",
-      "integrity": "sha512-8Fc5Ko5Y4URIJkmMF/iFP1C0/OJyY+VGVe9Nw6WAdZyw4bTO+eVg9mwxWkQp/y8NnAoQY3o9KAvE1ZdA2v+Vmg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
+      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -2739,19 +3176,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.0.tgz",
-      "integrity": "sha512-P7Nvwuli8WBNmeMHHek7PnGW4oAZl9za1fddfRVidZar8wDZRi7hpznLKQePQ8JPLwSBEYDK11g+++j7uFJV8Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.1.tgz",
+      "integrity": "sha512-VZ40MBnlE1/V5uTgdqY3DmjUgZtIzsYq758JGlyQrv5syIsaYcabkfPkEuWML49Ph0D/SoqpVFd0dyVTr551oA==",
       "dev": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.0",
-        "@vitest/mocker": "3.2.0",
-        "@vitest/pretty-format": "^3.2.0",
-        "@vitest/runner": "3.2.0",
-        "@vitest/snapshot": "3.2.0",
-        "@vitest/spy": "3.2.0",
-        "@vitest/utils": "3.2.0",
+        "@vitest/expect": "3.2.1",
+        "@vitest/mocker": "3.2.1",
+        "@vitest/pretty-format": "^3.2.1",
+        "@vitest/runner": "3.2.1",
+        "@vitest/snapshot": "3.2.1",
+        "@vitest/spy": "3.2.1",
+        "@vitest/utils": "3.2.1",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -2765,7 +3202,7 @@
         "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.0",
+        "vite-node": "3.2.1",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2781,8 +3218,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.0",
-        "@vitest/ui": "3.2.0",
+        "@vitest/browser": "3.2.1",
+        "@vitest/ui": "3.2.1",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -2880,6 +3317,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.18.2",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.6.3",
     "@vitest/ui": "^3.2.0",
+    "canvas": "^3.1.0",
     "jsdom": "^26.1.0",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",
     "vite-plugin-solid": "^2.11.6",
-    "vitest": "^3.2.0"
+    "vitest": "^3.2.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import OutputDisplay from './components/OutputDisplay';
 import ExponentSlider from './components/ExponentSlider';
 import MantissaSlider from './components/MantissaSlider';
 import VisualValueAdjuster from './components/VisualValueAdjuster'; // Added
+import SpecialValueButtons from './components/SpecialValueButtons'; // Added
 import {
   convertDecimalToBits,
   convertBitsToDecimal,
@@ -239,6 +240,11 @@ const App: Component = () => {
                           // This also sets isLastChangeFromSliders = true, which is acceptable
   };
 
+  const handleSpecialValueClick = (value: string) => {
+    // This existing handler already sets the necessary flags for updating bits correctly
+    handleDecimalChange(value);
+  };
+
   return (
     <div class="app-container">
       <h1>IEEE 754 浮動小数点数シミュレータ</h1>
@@ -276,6 +282,7 @@ const App: Component = () => {
         decimalFromBits={decimalFromBits}
         originalInput={displayedOriginalInput}
       />
+      <SpecialValueButtons onSpecialValueClick={handleSpecialValueClick} />
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -259,14 +259,6 @@ const App: Component = () => {
 
         {/* Sliders and Bits Group, takes remaining width */}
         <div class="sliders-and-bits-group">
-          <ExponentSlider
-            value={storedExponentValue}
-            onInput={handleExponentSliderChange}
-          />
-          <MantissaSlider
-            value={mantissaFractionValue}
-            onInput={handleMantissaSliderChange}
-          />
           <BitRepresentationInput
             sign={signBitString}
             exponent={exponentBitString}
@@ -274,6 +266,8 @@ const App: Component = () => {
             onSignBitClick={handleSignBitClick}
             onExponentBitClick={handleExponentBitClick}
             onSignificandBitClick={handleSignificandBitClick}
+            exponentSlider={() => <ExponentSlider value={storedExponentValue} onInput={handleExponentSliderChange} />}
+            mantissaSlider={() => <MantissaSlider value={mantissaFractionValue} onInput={handleMantissaSliderChange} />}
           />
         </div> {/* Closes sliders-and-bits-group */}
       </div> {/* Closes interactive-controls-section */}

--- a/src/components/BitRepresentationInput.test.tsx
+++ b/src/components/BitRepresentationInput.test.tsx
@@ -181,8 +181,8 @@ describe('BitRepresentationInput component', () => {
         exponentSlider: mockExponentSlider,
       };
       render(() => <BitRepresentationInput {...propsWithExponentSlider} />);
-      expect(screen.getByText(/指数 \(内部値:/)).toBeTruthy();
-      expect(screen.getByText(exponentValue().toString())).toBeTruthy(); // Check for value rendering
+      // Precise check for the label including the dynamic value
+      expect(screen.getByText(new RegExp(`指数 \\(内部値: ${exponentValue()}\\):`))).toBeTruthy();
     });
 
     it('should render MantissaSlider when mantissaSlider prop is provided', () => {
@@ -191,9 +191,8 @@ describe('BitRepresentationInput component', () => {
         mantissaSlider: mockMantissaSlider,
       };
       render(() => <BitRepresentationInput {...propsWithMantissaSlider} />);
-      expect(screen.getByText(/仮数 \(小数部:/)).toBeTruthy();
-      // Mantissa value is formatted, so check for part of it or use a more robust query
-      expect(screen.getByText(mantissaValue().toFixed(5))).toBeTruthy();
+      // Precise check for the label including the dynamic value
+      expect(screen.getByText(new RegExp(`仮数 \\(小数部: ${mantissaValue().toFixed(5)}\\):`))).toBeTruthy();
     });
 
     it('should render both sliders when both props are provided', () => {
@@ -203,10 +202,8 @@ describe('BitRepresentationInput component', () => {
         mantissaSlider: mockMantissaSlider,
       };
       render(() => <BitRepresentationInput {...propsWithBothSliders} />);
-      expect(screen.getByText(/指数 \(内部値:/)).toBeTruthy();
-      expect(screen.getByText(exponentValue().toString())).toBeTruthy();
-      expect(screen.getByText(/仮数 \(小数部:/)).toBeTruthy();
-      expect(screen.getByText(mantissaValue().toFixed(5))).toBeTruthy();
+      expect(screen.getByText(new RegExp(`指数 \\(内部値: ${exponentValue()}\\):`))).toBeTruthy();
+      expect(screen.getByText(new RegExp(`仮数 \\(小数部: ${mantissaValue().toFixed(5)}\\):`))).toBeTruthy();
     });
 
     it('should not render sliders if props are not provided (already covered by first test, but explicit)', () => {

--- a/src/components/BitRepresentationInput.test.tsx
+++ b/src/components/BitRepresentationInput.test.tsx
@@ -199,8 +199,8 @@ describe('BitRepresentationInput component', () => {
         exponentSlider: mockExponentSlider,
       };
       render(() => <BitRepresentationInput {...propsWithExponentSlider} />);
-      // Precise check for the label including the dynamic value
-      expect(screen.getByText(new RegExp(`指数 \\(内部値: ${exponentValue()}\\):`))).toBeTruthy();
+      // Precise check for the new simplified label including the dynamic value
+      expect(screen.getByText(new RegExp(`内部値: ${exponentValue()}`))).toBeTruthy();
     });
 
     it('should render MantissaSlider when mantissaSlider prop is provided', () => {
@@ -209,8 +209,8 @@ describe('BitRepresentationInput component', () => {
         mantissaSlider: mockMantissaSlider,
       };
       render(() => <BitRepresentationInput {...propsWithMantissaSlider} />);
-      // Precise check for the label including the dynamic value
-      expect(screen.getByText(new RegExp(`仮数 \\(小数部: ${mantissaValue().toFixed(5)}\\):`))).toBeTruthy();
+      // Precise check for the new simplified label including the dynamic value
+      expect(screen.getByText(new RegExp(`小数部: ${mantissaValue().toFixed(5)}`))).toBeTruthy();
     });
 
     it('should render both sliders when both props are provided', () => {
@@ -220,14 +220,18 @@ describe('BitRepresentationInput component', () => {
         mantissaSlider: mockMantissaSlider,
       };
       render(() => <BitRepresentationInput {...propsWithBothSliders} />);
-      expect(screen.getByText(new RegExp(`指数 \\(内部値: ${exponentValue()}\\):`))).toBeTruthy();
-      expect(screen.getByText(new RegExp(`仮数 \\(小数部: ${mantissaValue().toFixed(5)}\\):`))).toBeTruthy();
+      expect(screen.getByText(new RegExp(`内部値: ${exponentValue()}`))).toBeTruthy();
+      expect(screen.getByText(new RegExp(`小数部: ${mantissaValue().toFixed(5)}`))).toBeTruthy();
     });
 
     it('should not render sliders if props are not provided (already covered by first test, but explicit)', () => {
       render(() => <BitRepresentationInput {...mockBasicProps} />);
+      // Ensure old prefixed labels are not present
       expect(screen.queryByText(/指数 \(内部値:/)).toBeNull();
       expect(screen.queryByText(/仮数 \(小数部:/)).toBeNull();
+      // Ensure new simplified labels (without props that would make them render) are not present
+      expect(screen.queryByText(/内部値:/)).toBeNull();
+      expect(screen.queryByText(/小数部:/)).toBeNull();
     });
   });
 });

--- a/src/components/BitRepresentationInput.test.tsx
+++ b/src/components/BitRepresentationInput.test.tsx
@@ -46,6 +46,11 @@ describe('BitRepresentationInput component', () => {
 
     const signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('1');
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
+
+    setSign('0');
+    expect(signBit?.textContent).toBe('0');
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
   });
 
   it('should call onSignBitClick when sign bit is clicked', () => {
@@ -67,7 +72,9 @@ describe('BitRepresentationInput component', () => {
     const exponentBits = document.querySelectorAll('.clickable-bit.exponent-bit-span');
     expect(exponentBits).toHaveLength(11);
     expect(exponentBits[0].textContent).toBe('1');
+    expect(exponentBits[0].classList.contains('bit-one')).toBe(true);
     expect(exponentBits[1].textContent).toBe('0');
+    expect(exponentBits[1].classList.contains('bit-zero')).toBe(true);
   });
 
   it('should call onExponentBitClick with correct index', () => {
@@ -92,8 +99,11 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
     expect(significandBits).toHaveLength(52);
     expect(significandBits[0].textContent).toBe('1');
+    expect(significandBits[0].classList.contains('bit-one')).toBe(true);
     expect(significandBits[1].textContent).toBe('0');
+    expect(significandBits[1].classList.contains('bit-zero')).toBe(true);
     expect(significandBits[2].textContent).toBe('1');
+    expect(significandBits[2].classList.contains('bit-one')).toBe(true);
   });
 
   it('should call onSignificandBitClick with correct index', () => {
@@ -120,14 +130,20 @@ describe('BitRepresentationInput component', () => {
 
     let signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('0');
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
 
     setSign('1');
+    // Re-query after state change if component re-renders, or ensure reactivity handles class update
     signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit?.textContent).toBe('1');
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
 
     setExponent('10000000000');
     const exponentBits = document.querySelectorAll('.clickable-bit.exponent-bit-span');
     expect(exponentBits[0].textContent).toBe('1');
+    expect(exponentBits[0].classList.contains('bit-one')).toBe(true);
+    expect(exponentBits[1].textContent).toBe('0');
+    expect(exponentBits[1].classList.contains('bit-zero')).toBe(true);
   });
 
   it('should handle edge case with all zeros', () => {
@@ -145,8 +161,9 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
 
     expect(signBit?.textContent).toBe('0');
-    expect(Array.from(exponentBits).every(bit => bit.textContent === '0')).toBe(true);
-    expect(Array.from(significandBits).every(bit => bit.textContent === '0')).toBe(true);
+    expect(signBit?.classList.contains('bit-zero')).toBe(true);
+    expect(Array.from(exponentBits).every(bit => bit.textContent === '0' && bit.classList.contains('bit-zero'))).toBe(true);
+    expect(Array.from(significandBits).every(bit => bit.textContent === '0' && bit.classList.contains('bit-zero'))).toBe(true);
   });
 
   it('should handle edge case with all ones', () => {
@@ -164,8 +181,9 @@ describe('BitRepresentationInput component', () => {
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
 
     expect(signBit?.textContent).toBe('1');
-    expect(Array.from(exponentBits).every(bit => bit.textContent === '1')).toBe(true);
-    expect(Array.from(significandBits).every(bit => bit.textContent === '1')).toBe(true);
+    expect(signBit?.classList.contains('bit-one')).toBe(true);
+    expect(Array.from(exponentBits).every(bit => bit.textContent === '1' && bit.classList.contains('bit-one'))).toBe(true);
+    expect(Array.from(significandBits).every(bit => bit.textContent === '1' && bit.classList.contains('bit-one'))).toBe(true);
   });
 
   // New tests for sliders

--- a/src/components/BitRepresentationInput.test.tsx
+++ b/src/components/BitRepresentationInput.test.tsx
@@ -1,34 +1,46 @@
 import { render, fireEvent, screen } from '@solidjs/testing-library';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createSignal } from 'solid-js';
+import { createSignal, JSX } from 'solid-js'; // Added JSX
 import BitRepresentationInput from './BitRepresentationInput';
+import ExponentSlider from './ExponentSlider'; // Import ExponentSlider
+import MantissaSlider from './MantissaSlider'; // Import MantissaSlider
 
 describe('BitRepresentationInput component', () => {
-  const mockProps = {
+  const mockBasicProps = { // Renamed for clarity
     sign: () => '0',
     exponent: () => '01111111111',
     significand: () => '1001001000011111101101010100010001000010110100011000',
     onSignBitClick: vi.fn(),
     onExponentBitClick: vi.fn(),
     onSignificandBitClick: vi.fn(),
+    // Sliders are optional, so not included in basic props by default
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset mockProps to a clean state for each test if they are modified within tests
+    // This might involve redefining parts of mockBasicProps if necessary, e.g. mock functions
+    mockBasicProps.onSignBitClick = vi.fn();
+    mockBasicProps.onExponentBitClick = vi.fn();
+    mockBasicProps.onSignificandBitClick = vi.fn();
   });
 
-  it('should render all bit sections with correct labels', () => {
-    render(() => <BitRepresentationInput {...mockProps} />);
+  it('should render all bit sections with correct labels without sliders', () => {
+    render(() => <BitRepresentationInput {...mockBasicProps} />);
 
     expect(screen.getByText('ビット表現 (IEEE 754 64ビット)')).toBeTruthy();
     expect(screen.getByText('符号 (1ビット):')).toBeTruthy();
     expect(screen.getByText('指数 (11ビット):')).toBeTruthy();
     expect(screen.getByText('仮数 (52ビット):')).toBeTruthy();
+
+    // Ensure slider-specific texts are not present
+    expect(screen.queryByText(/指数 \(内部値:/)).toBeNull();
+    expect(screen.queryByText(/仮数 \(小数部:/)).toBeNull();
   });
 
   it('should display sign bit correctly', () => {
     const [sign, setSign] = createSignal('1');
-    const props = { ...mockProps, sign };
+    const props = { ...mockBasicProps, sign };
 
     render(() => <BitRepresentationInput {...props} />);
 
@@ -37,18 +49,18 @@ describe('BitRepresentationInput component', () => {
   });
 
   it('should call onSignBitClick when sign bit is clicked', () => {
-    render(() => <BitRepresentationInput {...mockProps} />);
+    render(() => <BitRepresentationInput {...mockBasicProps} />);
 
     const signBit = document.querySelector('.clickable-bit.sign-bit-span');
     expect(signBit).toBeTruthy();
     
     fireEvent.click(signBit!);
-    expect(mockProps.onSignBitClick).toHaveBeenCalledTimes(1);
+    expect(mockBasicProps.onSignBitClick).toHaveBeenCalledTimes(1);
   });
 
   it('should display exponent bits correctly', () => {
     const [exponent, setExponent] = createSignal('10000000000');
-    const props = { ...mockProps, exponent };
+    const props = { ...mockBasicProps, exponent };
 
     render(() => <BitRepresentationInput {...props} />);
 
@@ -59,21 +71,21 @@ describe('BitRepresentationInput component', () => {
   });
 
   it('should call onExponentBitClick with correct index', () => {
-    render(() => <BitRepresentationInput {...mockProps} />);
+    render(() => <BitRepresentationInput {...mockBasicProps} />);
 
     const exponentBits = document.querySelectorAll('.clickable-bit.exponent-bit-span');
     
     fireEvent.click(exponentBits[0]);
-    expect(mockProps.onExponentBitClick).toHaveBeenCalledWith(0);
+    expect(mockBasicProps.onExponentBitClick).toHaveBeenCalledWith(0);
     
     fireEvent.click(exponentBits[5]);
-    expect(mockProps.onExponentBitClick).toHaveBeenCalledWith(5);
+    expect(mockBasicProps.onExponentBitClick).toHaveBeenCalledWith(5);
   });
 
   it('should display significand bits correctly', () => {
     const testSignificand = '1010101010101010101010101010101010101010101010101010';
     const [significand, setSignificand] = createSignal(testSignificand);
-    const props = { ...mockProps, significand };
+    const props = { ...mockBasicProps, significand };
 
     render(() => <BitRepresentationInput {...props} />);
 
@@ -85,24 +97,24 @@ describe('BitRepresentationInput component', () => {
   });
 
   it('should call onSignificandBitClick with correct index', () => {
-    render(() => <BitRepresentationInput {...mockProps} />);
+    render(() => <BitRepresentationInput {...mockBasicProps} />);
 
     const significandBits = document.querySelectorAll('.clickable-bit.significand-bit-span');
     
     fireEvent.click(significandBits[0]);
-    expect(mockProps.onSignificandBitClick).toHaveBeenCalledWith(0);
+    expect(mockBasicProps.onSignificandBitClick).toHaveBeenCalledWith(0);
     
     fireEvent.click(significandBits[25]);
-    expect(mockProps.onSignificandBitClick).toHaveBeenCalledWith(25);
+    expect(mockBasicProps.onSignificandBitClick).toHaveBeenCalledWith(25);
     
     fireEvent.click(significandBits[51]);
-    expect(mockProps.onSignificandBitClick).toHaveBeenCalledWith(51);
+    expect(mockBasicProps.onSignificandBitClick).toHaveBeenCalledWith(51);
   });
 
   it('should update when bit values change', () => {
     const [sign, setSign] = createSignal('0');
     const [exponent, setExponent] = createSignal('01111111111');
-    const props = { ...mockProps, sign, exponent };
+    const props = { ...mockBasicProps, sign, exponent };
 
     render(() => <BitRepresentationInput {...props} />);
 
@@ -120,7 +132,7 @@ describe('BitRepresentationInput component', () => {
 
   it('should handle edge case with all zeros', () => {
     const zeroProps = {
-      ...mockProps,
+      ...mockBasicProps,
       sign: () => '0',
       exponent: () => '00000000000',
       significand: () => '0000000000000000000000000000000000000000000000000000',
@@ -139,7 +151,7 @@ describe('BitRepresentationInput component', () => {
 
   it('should handle edge case with all ones', () => {
     const onesProps = {
-      ...mockProps,
+      ...mockBasicProps,
       sign: () => '1',
       exponent: () => '11111111111',
       significand: () => '1111111111111111111111111111111111111111111111111111',
@@ -154,5 +166,53 @@ describe('BitRepresentationInput component', () => {
     expect(signBit?.textContent).toBe('1');
     expect(Array.from(exponentBits).every(bit => bit.textContent === '1')).toBe(true);
     expect(Array.from(significandBits).every(bit => bit.textContent === '1')).toBe(true);
+  });
+
+  // New tests for sliders
+  describe('Slider integration', () => {
+    const [exponentValue, setExponentValue] = createSignal(1023);
+    const [mantissaValue, setMantissaValue] = createSignal(0.5);
+    const mockExponentSlider = () => <ExponentSlider value={exponentValue} onInput={vi.fn()} />;
+    const mockMantissaSlider = () => <MantissaSlider value={mantissaValue} onInput={vi.fn()} />;
+
+    it('should render ExponentSlider when exponentSlider prop is provided', () => {
+      const propsWithExponentSlider = {
+        ...mockBasicProps,
+        exponentSlider: mockExponentSlider,
+      };
+      render(() => <BitRepresentationInput {...propsWithExponentSlider} />);
+      expect(screen.getByText(/指数 \(内部値:/)).toBeTruthy();
+      expect(screen.getByText(exponentValue().toString())).toBeTruthy(); // Check for value rendering
+    });
+
+    it('should render MantissaSlider when mantissaSlider prop is provided', () => {
+      const propsWithMantissaSlider = {
+        ...mockBasicProps,
+        mantissaSlider: mockMantissaSlider,
+      };
+      render(() => <BitRepresentationInput {...propsWithMantissaSlider} />);
+      expect(screen.getByText(/仮数 \(小数部:/)).toBeTruthy();
+      // Mantissa value is formatted, so check for part of it or use a more robust query
+      expect(screen.getByText(mantissaValue().toFixed(5))).toBeTruthy();
+    });
+
+    it('should render both sliders when both props are provided', () => {
+      const propsWithBothSliders = {
+        ...mockBasicProps,
+        exponentSlider: mockExponentSlider,
+        mantissaSlider: mockMantissaSlider,
+      };
+      render(() => <BitRepresentationInput {...propsWithBothSliders} />);
+      expect(screen.getByText(/指数 \(内部値:/)).toBeTruthy();
+      expect(screen.getByText(exponentValue().toString())).toBeTruthy();
+      expect(screen.getByText(/仮数 \(小数部:/)).toBeTruthy();
+      expect(screen.getByText(mantissaValue().toFixed(5))).toBeTruthy();
+    });
+
+    it('should not render sliders if props are not provided (already covered by first test, but explicit)', () => {
+      render(() => <BitRepresentationInput {...mockBasicProps} />);
+      expect(screen.queryByText(/指数 \(内部値:/)).toBeNull();
+      expect(screen.queryByText(/仮数 \(小数部:/)).toBeNull();
+    });
   });
 });

--- a/src/components/BitRepresentationInput.tsx
+++ b/src/components/BitRepresentationInput.tsx
@@ -21,7 +21,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
         <div class="bit-group sign-bit">
           <label>符号 (1ビット):</label>
           {/* No scroll container needed for a single bit */}
-          <span class="clickable-bit sign-bit-span" onClick={() => props.onSignBitClick()}>
+          <span class={`clickable-bit sign-bit-span ${props.sign() === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onSignBitClick()}>
             {props.sign()}
           </span>
         </div>
@@ -31,7 +31,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
             {props.exponentSlider && props.exponentSlider()}
             <div class="bits-scroll-container">
               {props.exponent().split('').map((bit, index) => (
-                <span class="clickable-bit exponent-bit-span" onClick={() => props.onExponentBitClick(index)}>
+                <span class={`clickable-bit exponent-bit-span ${bit === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onExponentBitClick(index)}>
                   {bit}
                 </span>
               ))}
@@ -44,7 +44,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
             {props.mantissaSlider && props.mantissaSlider()}
             <div class="bits-scroll-container">
               {props.significand().split('').map((bit, index) => (
-                <span class="clickable-bit significand-bit-span" onClick={() => props.onSignificandBitClick(index)}>
+                <span class={`clickable-bit significand-bit-span ${bit === '0' ? 'bit-zero' : 'bit-one'}`} onClick={() => props.onSignificandBitClick(index)}>
                   {bit}
                 </span>
               ))}

--- a/src/components/BitRepresentationInput.tsx
+++ b/src/components/BitRepresentationInput.tsx
@@ -26,25 +26,29 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
           </span>
         </div>
         <div class="bit-group exponent-bits">
-          {props.exponentSlider && props.exponentSlider()}
           <label>指数 ({EXPONENT_BITS}ビット):</label>
-          <div class="bits-scroll-container">
-            {props.exponent().split('').map((bit, index) => (
-              <span class="clickable-bit exponent-bit-span" onClick={() => props.onExponentBitClick(index)}>
-                {bit}
-              </span>
-            ))}
+          <div class="slider-and-bits-row">
+            {props.exponentSlider && props.exponentSlider()}
+            <div class="bits-scroll-container">
+              {props.exponent().split('').map((bit, index) => (
+                <span class="clickable-bit exponent-bit-span" onClick={() => props.onExponentBitClick(index)}>
+                  {bit}
+                </span>
+              ))}
+            </div>
           </div>
         </div>
         <div class="bit-group significand-bits">
-          {props.mantissaSlider && props.mantissaSlider()}
           <label>仮数 ({SIGNIFICAND_BITS}ビット):</label>
-          <div class="bits-scroll-container">
-            {props.significand().split('').map((bit, index) => (
-              <span class="clickable-bit significand-bit-span" onClick={() => props.onSignificandBitClick(index)}>
-                {bit}
-              </span>
-            ))}
+          <div class="slider-and-bits-row">
+            {props.mantissaSlider && props.mantissaSlider()}
+            <div class="bits-scroll-container">
+              {props.significand().split('').map((bit, index) => (
+                <span class="clickable-bit significand-bit-span" onClick={() => props.onSignificandBitClick(index)}>
+                  {bit}
+                </span>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/BitRepresentationInput.tsx
+++ b/src/components/BitRepresentationInput.tsx
@@ -1,5 +1,5 @@
 // src/components/BitRepresentationInput.tsx
-import type { Component, Accessor } from 'solid-js';
+import type { Component, Accessor, JSX } from 'solid-js';
 import { EXPONENT_BITS, SIGNIFICAND_BITS } from '../utils/ieee754';
 
 interface BitRepresentationInputProps {
@@ -9,6 +9,8 @@ interface BitRepresentationInputProps {
   onSignBitClick: () => void;
   onExponentBitClick: (index: number) => void;
   onSignificandBitClick: (index: number) => void;
+  exponentSlider?: () => JSX.Element;
+  mantissaSlider?: () => JSX.Element;
 }
 
 const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) => {
@@ -24,6 +26,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
           </span>
         </div>
         <div class="bit-group exponent-bits">
+          {props.exponentSlider && props.exponentSlider()}
           <label>指数 ({EXPONENT_BITS}ビット):</label>
           <div class="bits-scroll-container">
             {props.exponent().split('').map((bit, index) => (
@@ -34,6 +37,7 @@ const BitRepresentationInput: Component<BitRepresentationInputProps> = (props) =
           </div>
         </div>
         <div class="bit-group significand-bits">
+          {props.mantissaSlider && props.mantissaSlider()}
           <label>仮数 ({SIGNIFICAND_BITS}ビット):</label>
           <div class="bits-scroll-container">
             {props.significand().split('').map((bit, index) => (

--- a/src/components/ExponentSlider.tsx
+++ b/src/components/ExponentSlider.tsx
@@ -21,7 +21,7 @@ const ExponentSlider: Component<ExponentSliderProps> = (props) => {
 
   return (
     <div class="slider-section">
-      <label for="exponentSlider">指数 (内部値: {props.value()}):</label>
+      <label for="exponentSlider">内部値: {props.value()}</label>
       <input
         type="range"
         id="exponentSlider"

--- a/src/components/MantissaSlider.tsx
+++ b/src/components/MantissaSlider.tsx
@@ -21,7 +21,7 @@ const MantissaSlider: Component<MantissaSliderProps> = (props) => {
 
   return (
     <div class="slider-section">
-      <label for="mantissaSlider">仮数 (小数部: {props.value().toFixed(5)}):</label>
+      <label for="mantissaSlider">小数部: {props.value().toFixed(5)}</label>
       <input
         type="range"
         id="mantissaSlider"

--- a/src/components/SpecialValueButtons.tsx
+++ b/src/components/SpecialValueButtons.tsx
@@ -1,0 +1,43 @@
+// src/components/SpecialValueButtons.tsx
+import type { Component } from 'solid-js';
+import './components.css'; // Assuming shared CSS
+
+interface SpecialValueButtonsProps {
+  onSpecialValueClick: (value: string) => void;
+}
+
+const SpecialValueButtons: Component<SpecialValueButtonsProps> = (props) => {
+  const values = [
+    { label: 'NaN', value: 'NaN' },
+    { label: 'Infinity', value: 'Infinity' },
+    { label: '-Infinity', value: '-Infinity' },
+    { label: '+0', value: '0.0' },
+    { label: '-0', value: '-0.0' }, // IEEE 754 distinguishes +0 and -0
+    { label: '1', value: '1.0' },
+    // For "Epsilon", we'll use Number.EPSILON, which is the difference between 1 and the smallest float greater than 1.
+    // The smallest positive normalized number is different, it's Number.MIN_VALUE for double precision.
+    // Let's clarify which one is needed. For now, using Number.EPSILON as it's a common "small" float value.
+    { label: 'Epsilon', value: Number.EPSILON.toString() },
+    { label: 'Min Normal', value: Number.MIN_VALUE.toString()}, // Smallest positive normal for double
+    { label: 'Max Value', value: Number.MAX_VALUE.toString() } // Max finite value for double
+  ];
+
+  return (
+    <div class="special-buttons-container">
+      <h3>特定の値に設定:</h3>
+      <div class="buttons-wrapper"> {/* Added wrapper for flex layout */}
+        {values.map(item => (
+          <button
+            type="button"
+            class="special-value-button"
+          onClick={() => props.onSpecialValueClick(item.value)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SpecialValueButtons;

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -153,8 +153,26 @@ input[type='text']:focus {
 }
 
 .clickable-bit:hover {
-  background-color: #f0f0f0;
+  /* background-color: #f0f0f0; */ /* Generic hover background removed, handled by specific bit types */
   border-color: #aaa;
+}
+
+.bit-zero {
+  background-color: #e0e0e0;
+}
+
+.bit-one {
+  background-color: #a0d3ff;
+}
+
+.bit-zero:hover {
+  background-color: #d0d0d0;
+  /* border-color is inherited from .clickable-bit:hover */
+}
+
+.bit-one:hover {
+  background-color: #8acaff;
+  /* border-color is inherited from .clickable-bit:hover */
 }
 
 /* Specific bit spans can inherit from clickable-bit. Add specific styles if needed. */
@@ -301,3 +319,50 @@ input[type='text']:focus {
   background-color: #ffffff; // Slight distinction from section background
 }
 */
+
+/* Styles for SpecialValueButtons */
+.special-buttons-container {
+  margin-top: 20px;
+  padding: 15px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.special-buttons-container h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  color: #333;
+  font-size: 1.1em;
+  text-align: center; /* Center the heading */
+}
+
+.buttons-wrapper { /* Style for the added wrapper */
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px; /* Adds space between buttons */
+}
+
+.special-value-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 8px 12px;
+  /* margin: 5px; Remove individual margins if using gap */
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 0.9em;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.special-value-button:hover {
+  background-color: #0056b3;
+}
+
+.special-value-button:active {
+  background-color: #004085;
+}

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -94,6 +94,26 @@ input[type='text']:focus {
   /* margin-bottom: 4px; */ /* Adjust spacing for slider's own label */
 }
 
+/* New styles for horizontal alignment of slider and bits */
+.slider-and-bits-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center; /* Vertically align slider and bits container */
+  gap: 15px; /* Space between slider and bits container */
+  margin-top: 5px; /* Space below the main label of the bit group */
+}
+
+.slider-and-bits-row .slider-section {
+  flex-shrink: 0; /* Prevent slider from shrinking disproportionately */
+  flex-basis: 220px; /* Base width for the slider section */
+  /* Existing .bit-group .slider-section rules for transparency, no border, etc., will still apply */
+}
+
+.slider-and-bits-row .bits-scroll-container {
+  flex-grow: 1; /* Allow bit container to take remaining space */
+  min-width: 0; /* Essential for scrollable content in flex item */
+}
+
 .bit-group input[type='text'] {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   letter-spacing: 1.5px;

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -79,6 +79,21 @@ input[type='text']:focus {
   margin-bottom: 6px;
 }
 
+/* Styles for sliders when they are inside a bit-group */
+.bit-group .slider-section {
+  margin-top: 5px; /* Reduced top margin */
+  margin-bottom: 10px; /* Add some space before the bit label */
+  padding: 5px; /* Reduced padding */
+  border: none; /* No border */
+  background-color: transparent; /* Blend with parent background */
+}
+
+/* Ensure slider labels are distinct if needed, though they are already specific */
+.bit-group .slider-section label {
+  /* font-weight: bold; */ /* Example: if needed to differentiate */
+  /* margin-bottom: 4px; */ /* Adjust spacing for slider's own label */
+}
+
 .bit-group input[type='text'] {
   font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   letter-spacing: 1.5px;


### PR DESCRIPTION
…tions

This change relocates the exponent and mantissa sliders to be visually adjacent to their respective bit display sections within the IEEE 754 simulator.

To achieve this:
- `BitRepresentationInput.tsx` was modified to accept optional `exponentSlider` and `mantissaSlider` components as props. These are then rendered directly above their corresponding bit groups (exponent and significand/mantissa).
- `App.tsx` was updated to pass the `ExponentSlider` and `MantissaSlider` instances as props to `BitRepresentationInput`, removing them from their previous location.
- CSS in `components.css` was adjusted for sliders rendered within `.bit-group` to ensure they integrate visually (removed extra borders, padding, and adjusted margins).
- Unit tests for `BitRepresentationInput.tsx` were updated to include test cases for the new optional slider props, ensuring they are rendered correctly when provided and that the component functions as expected with and without them.