### PR TITLE
feat: Introduce solid-styled-components and refactor NumberInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "decimal.js": "^10.5.0",
-        "solid-js": "^1.9.5"
+        "solid-js": "^1.9.5",
+        "solid-styled-components": "^0.28.5"
       },
       "devDependencies": {
         "@solidjs/testing-library": "^0.8.10",
@@ -1862,6 +1863,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2395,6 +2404,18 @@
       },
       "peerDependencies": {
         "solid-js": "^1.3"
+      }
+    },
+    "node_modules/solid-styled-components": {
+      "version": "0.28.5",
+      "resolved": "https://registry.npmjs.org/solid-styled-components/-/solid-styled-components-0.28.5.tgz",
+      "integrity": "sha512-vwTcdp76wZNnESIzB6rRZ3U55NgcSAQXCiiRIiEFhxTFqT0bEh/warNT1qaRZu4OkAzrBkViOngF35ktI8sc4A==",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "goober": "^2.1.10"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.4.4"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "decimal.js": "^10.5.0",
-    "solid-js": "^1.9.5"
+    "solid-js": "^1.9.5",
+    "solid-styled-components": "^0.28.5"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -1,14 +1,46 @@
 // src/components/NumberInput.tsx
 import type { Component, Accessor } from 'solid-js';
+import { styled } from 'solid-styled-components';
 
 interface NumberInputProps {
   value: Accessor<string>;
   onInput: (value: string) => void;
 }
 
+const StyledNumberInputContainer = styled.div`
+  margin-bottom: 25px;
+  padding: 20px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: #f9f9f9;
+
+  label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #555;
+  }
+
+  input[type='text'] {
+    width: 100%;
+    padding: 12px;
+    margin-bottom: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-sizing: border-box;
+    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  input[type='text']:focus {
+    border-color: #1a73e8;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.25);
+  }
+`;
+
 const NumberInput: Component<NumberInputProps> = (props) => {
   return (
-    <div class="input-section">
+    <StyledNumberInputContainer>
       <label for="decimalValue">数値:</label>
       <input
         type="text" // Use text to allow 'NaN', 'Infinity'
@@ -17,7 +49,7 @@ const NumberInput: Component<NumberInputProps> = (props) => {
         value={props.value()}
         onInput={(e) => props.onInput(e.currentTarget.value)}
       />
-    </div>
+    </StyledNumberInputContainer>
   );
 };
 export default NumberInput;

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -14,7 +14,6 @@
   margin-bottom: 25px;
 }
 
-.input-section,
 .bit-representation-section,
 .output-section {
   margin-bottom: 25px;


### PR DESCRIPTION
I've installed `solid-styled-components` to enable component-specific styling.

I also refactored the `NumberInput` component to use `solid-styled-components`:
- Defined a `StyledNumberInputContainer` within `NumberInput.tsx`.
- Migrated the CSS styles for the component from the global `components.css` to this new styled component.
- Removed the corresponding `.input-section` styles from `components.css`.

Unit tests for `NumberInput.tsx` continue to pass, indicating no functional regressions were introduced. This change allows for better style encapsulation and modularity for the `NumberInput` component.