### PR TITLE
Fix: Mantissa slider and bit display for exponent 2047

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,9 +144,12 @@ const App: Component = () => {
             if (parseInt(m, 2) === 0) { // Infinity
               setMantissaFractionValue(0);
             } else { // NaN
-              setMantissaFractionValue(0.5); // Or some other representative NaN fraction
+              // For NaN, the mantissa slider should reflect the actual fraction from bits 'm'
+              setMantissaFractionValue(bitsToMantissaFraction(m));
             }
           }
+          // For non-special numbers, setMantissaFractionValue(bitsToMantissaFraction(m))
+          // is already called prior to this special handling block, so no 'else' needed here.
         });
       }
       return result;
@@ -178,11 +181,9 @@ const App: Component = () => {
         // Mantissa slider determines NaN or Infinity
         if (currentMantissaFraction === 0) { // Infinity
           newSignificandBits = '0'.repeat(SIGNIFICAND_BITS);
-        } else { // NaN - canonical qNaN is 1 + 0... (fraction 0.5), but any non-zero is NaN
-                   // For simplicity, if mantissa slider is > 0 and exponent is max, make it a qNaN.
-                   // A common qNaN is first bit of mantissa set.
-          newSignificandBits = '1' + '0'.repeat(SIGNIFICAND_BITS - 1);
-          // We could also choose to set mantissaFractionValue to 0.5 here if we want slider to snap to that for NaN
+        } else { // NaN (currentMantissaFraction > 0)
+          // Generate significand bits from the actual mantissa fraction for NaN
+          newSignificandBits = mantissaFractionToBits(currentMantissaFraction, SIGNIFICAND_BITS);
         }
       }
 


### PR DESCRIPTION
This addresses a bug where, with the exponent at 2047 (max value):
1. Moving the mantissa slider did not change the significand bit display if the mantissa was > 0 (NaN case). The bits were stuck at '100...0'.
2. Toggling significand bits to a non-zero value always forced the mantissa slider to 0.5, instead of reflecting the actual fractional value of the bits.

The fix ensures that:
- When the exponent is 2047, the `handleSliderChange` function now correctly converts the mantissa slider's fractional value (>0) to the corresponding significand bits using `mantissaFractionToBits`.
- When the exponent is 2047 and significand bits are modified (for a NaN), the `decimalFromBits` memo now correctly updates the mantissa slider's value using `bitsToMantissaFraction`, reflecting the true fractional value of the significand.

Infinity handling (exponent 2047, significand all zeros, mantissa slider at 0) remains correct.