### PR TITLE
Make 2D visual adjuster responsive and full-width

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -256,7 +256,7 @@ const App: Component = () => {
       {/* Interactive Controls Section */}
       <div class="interactive-controls-section">
         {/* Visual Adjuster might take up a certain portion of width */}
-        <div style="flex-basis: 320px; /* Adjust as needed based on VisualValueAdjuster width */">
+        <div>
           <VisualValueAdjuster
             storedExponent={storedExponentValue}
             mantissaFraction={mantissaFractionValue}

--- a/src/components/VisualValueAdjuster.tsx
+++ b/src/components/VisualValueAdjuster.tsx
@@ -9,8 +9,7 @@ interface VisualValueAdjusterProps {
   onPositionChange: (exponent: number, fraction: number) => void;
 }
 
-const WIDTH = 450;
-const HEIGHT = 200;
+const FIXED_HEIGHT = 200;
 const POINT_RADIUS = 5;
 const LABEL_OFFSET = 20; // For axis labels
 
@@ -18,6 +17,7 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
   let canvasRef: HTMLCanvasElement | undefined;
   let isDragging = false;
   const MAX_STORED_EXPONENT = (1 << EXPONENT_BITS) - 1; // 2047
+  let resizeObserver: ResizeObserver | null = null;
 
   const getCanvasContext = (): CanvasRenderingContext2D | null => {
     return canvasRef ? canvasRef.getContext('2d') : null;
@@ -25,53 +25,54 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
 
   const draw = () => {
     const ctx = getCanvasContext();
-    if (!ctx) return;
+    if (!ctx || !canvasRef) return;
 
     // Clear canvas
-    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.clearRect(0, 0, canvasRef.width, FIXED_HEIGHT);
 
     // Define regions based on exponent value
-    const denormalizedZeroHeight = HEIGHT / (MAX_STORED_EXPONENT + 1); // Height for exp = 0
-    const specialHeight = HEIGHT / (MAX_STORED_EXPONENT + 1);       // Height for exp = MAX_STORED_EXPONENT
+    const denormalizedZeroHeight = FIXED_HEIGHT / (MAX_STORED_EXPONENT + 1); // Height for exp = 0
+    const specialHeight = FIXED_HEIGHT / (MAX_STORED_EXPONENT + 1);       // Height for exp = MAX_STORED_EXPONENT
 
     // Draw background for Zero/Denormalized region (exponent === 0)
     ctx.fillStyle = 'rgba(255, 255, 224, 0.7)'; // Light yellow
-    ctx.fillRect(0, HEIGHT - denormalizedZeroHeight, WIDTH, denormalizedZeroHeight);
+    ctx.fillRect(0, FIXED_HEIGHT - denormalizedZeroHeight, canvasRef.width, denormalizedZeroHeight);
 
     // Draw background for Infinity/NaN region (exponent === MAX_STORED_EXPONENT)
     ctx.fillStyle = 'rgba(255, 224, 224, 0.7)'; // Light red
-    ctx.fillRect(0, 0, WIDTH, specialHeight);
+    ctx.fillRect(0, 0, canvasRef.width, specialHeight);
 
     // Draw background for Normal numbers region
     ctx.fillStyle = 'rgba(224, 255, 224, 0.7)'; // Light green
-    ctx.fillRect(0, specialHeight, WIDTH, HEIGHT - specialHeight - denormalizedZeroHeight);
+    ctx.fillRect(0, specialHeight, canvasRef.width, FIXED_HEIGHT - specialHeight - denormalizedZeroHeight);
 
     // Draw Grid lines (optional, for better visual guidance)
     ctx.strokeStyle = '#ddd';
+    if (!canvasRef) return;
     ctx.lineWidth = 0.5;
     // Y-axis grid lines (for exponent)
     for (let i = 0; i <= MAX_STORED_EXPONENT; i += Math.floor(MAX_STORED_EXPONENT/10)) {
-        const y = HEIGHT - (i / MAX_STORED_EXPONENT) * HEIGHT;
+        const y = FIXED_HEIGHT - (i / MAX_STORED_EXPONENT) * FIXED_HEIGHT;
         ctx.beginPath();
         ctx.moveTo(0, y);
-        ctx.lineTo(WIDTH, y);
+        ctx.lineTo(canvasRef.width, y);
         ctx.stroke();
     }
     // X-axis grid lines (for mantissa)
     for (let i = 0; i <= 10; i++) {
-        const x = (i/10) * WIDTH;
+        const xPos = (i/10) * canvasRef.width;
         ctx.beginPath();
-        ctx.moveTo(x,0);
-        ctx.lineTo(x, HEIGHT);
+        ctx.moveTo(xPos,0);
+        ctx.lineTo(xPos, FIXED_HEIGHT);
         ctx.stroke();
     }
 
 
     // Calculate point position
-    // X: mantissaFraction (0 to <1) maps to 0 to WIDTH
-    const x = props.mantissaFraction() * WIDTH;
-    // Y: storedExponent (0 to MAX_STORED_EXPONENT) maps to HEIGHT (for 0) to 0 (for MAX)
-    const y = HEIGHT - (props.storedExponent() / MAX_STORED_EXPONENT) * HEIGHT;
+    // X: mantissaFraction (0 to <1) maps to 0 to canvasRef.width
+    const x = props.mantissaFraction() * canvasRef.width;
+    // Y: storedExponent (0 to MAX_STORED_EXPONENT) maps to FIXED_HEIGHT (for 0) to 0 (for MAX)
+    const y = FIXED_HEIGHT - (props.storedExponent() / MAX_STORED_EXPONENT) * FIXED_HEIGHT;
 
     // Draw the point
     ctx.beginPath();
@@ -84,16 +85,17 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
 
     // Draw axis labels
     ctx.fillStyle = '#333';
+    if (!canvasRef) return;
     ctx.font = '10px Arial';
     // Y-axis labels
     ctx.textAlign = 'left'; // Adjusted alignment for potentially longer Japanese text
-    ctx.fillText('0', 5, HEIGHT - 5); // Adjusted position
+    ctx.fillText('0', 5, FIXED_HEIGHT - 5); // Adjusted position
     ctx.fillText(`最大指数 (${MAX_STORED_EXPONENT})`, 5, 15); // Adjusted position & text
     // X-axis labels
     ctx.textAlign = 'left';
-    ctx.fillText('0.0', 5, HEIGHT - LABEL_OFFSET + 10 ); // Adjusted for consistency
+    ctx.fillText('0.0', 5, FIXED_HEIGHT - LABEL_OFFSET + 10 ); // Adjusted for consistency
     ctx.textAlign = 'right';
-    ctx.fillText('ほぼ1.0', WIDTH - 5, HEIGHT - LABEL_OFFSET + 10); // Adjusted position & text
+    ctx.fillText('ほぼ1.0', canvasRef.width - 5, FIXED_HEIGHT - LABEL_OFFSET + 10); // Adjusted position & text
   };
 
   const handleMouseEvent = (event: MouseEvent) => {
@@ -103,19 +105,19 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
     let mouseY = event.clientY - rect.top;
 
     // Clamp coordinates to canvas bounds
-    mouseX = Math.max(0, Math.min(WIDTH, mouseX));
-    mouseY = Math.max(0, Math.min(HEIGHT, mouseY));
+    mouseX = Math.max(0, Math.min(canvasRef.width, mouseX));
+    mouseY = Math.max(0, Math.min(FIXED_HEIGHT, mouseY));
 
     // Convert to newMantissaFraction and newExponent
-    let newMantissaFraction = mouseX / WIDTH;
-    // Ensure fraction is < 1.0. If mouseX is exactly WIDTH, newMantissaFraction becomes 1.0.
+    let newMantissaFraction = mouseX / canvasRef.width;
+    // Ensure fraction is < 1.0. If mouseX is exactly canvasRef.width, newMantissaFraction becomes 1.0.
     // (2**SIGNIFICAND_BITS -1) / 2**SIGNIFICAND_BITS is the largest fraction less than 1.
     // For simplicity, using Math.nextDown(1.0) or a slightly smaller hardcoded value.
     if (newMantissaFraction >= 1.0) {
         newMantissaFraction = Math.nextDown(1.0);
     }
 
-    const newExponent = Math.round(MAX_STORED_EXPONENT * (1 - mouseY / HEIGHT));
+    const newExponent = Math.round(MAX_STORED_EXPONENT * (1 - mouseY / FIXED_HEIGHT));
 
     props.onPositionChange(newExponent, newMantissaFraction);
   };
@@ -143,17 +145,17 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
     let touchY = touch.clientY - rect.top;
 
     // Clamp coordinates to canvas bounds
-    touchX = Math.max(0, Math.min(WIDTH, touchX));
-    touchY = Math.max(0, Math.min(HEIGHT, touchY));
+    touchX = Math.max(0, Math.min(canvasRef.width, touchX));
+    touchY = Math.max(0, Math.min(FIXED_HEIGHT, touchY));
 
     // Convert to newMantissaFraction and newExponent
-    let newMantissaFraction = touchX / WIDTH;
-    // Ensure fraction is < 1.0. If touchX is exactly WIDTH, newMantissaFraction becomes 1.0.
+    let newMantissaFraction = touchX / canvasRef.width;
+    // Ensure fraction is < 1.0. If touchX is exactly canvasRef.width, newMantissaFraction becomes 1.0.
     if (newMantissaFraction >= 1.0) {
         newMantissaFraction = Math.nextDown(1.0);
     }
 
-    const newExponent = Math.round(MAX_STORED_EXPONENT * (1 - touchY / HEIGHT));
+    const newExponent = Math.round(MAX_STORED_EXPONENT * (1 - touchY / FIXED_HEIGHT));
 
     props.onPositionChange(newExponent, newMantissaFraction);
   };
@@ -177,7 +179,34 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
   };
 
   onMount(() => {
+    if (!canvasRef || !canvasRef.parentElement) return;
+
+    const parentEl = canvasRef.parentElement;
+
+    resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target === parentEl && canvasRef) {
+          const newWidth = entry.contentRect.width;
+          canvasRef.width = newWidth;
+          canvasRef.height = FIXED_HEIGHT;
+          draw();
+        }
+      }
+    });
+
+    resizeObserver.observe(parentEl);
+
+    // Initial sizing based on parent
+    canvasRef.width = parentEl.clientWidth;
+    canvasRef.height = FIXED_HEIGHT;
     draw(); // Initial draw
+
+    // Cleanup observer on component unmount
+    return () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
   });
 
   // Re-draw when props change
@@ -189,8 +218,6 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
       <canvas
         id="visualAdjusterCanvas"
         ref={canvasRef}
-        width={WIDTH}
-        height={HEIGHT}
         onMouseDown={onMouseDown}
         onMouseMove={onMouseMove}
         onMouseUp={onMouseUpOrLeave}
@@ -198,7 +225,7 @@ const VisualValueAdjuster: Component<VisualValueAdjusterProps> = (props) => {
         onTouchStart={onTouchStartHandler}
         onTouchMove={onTouchMoveHandler}
         onTouchEnd={onTouchEndHandler}
-        style={{ cursor: 'crosshair', border: '1px solid black' }}
+        style={{ cursor: 'crosshair', border: '1px solid black', touchAction: 'none' }} // Added touchAction: 'none' to prevent scrolling on touch
       />
     </div>
   );

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -237,6 +237,7 @@ input[type='text']:focus {
   padding: 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
+  transition: none; /* Add this line */
   /* display: flex; */ /* Using this might require child elements to be adjusted */
   /* flex-direction: column; */
   /* align-items: center; */ /* Center canvas if it's narrower than section */
@@ -267,6 +268,7 @@ input[type='text']:focus {
   border: 1px solid #dcdcdc; /* Added border for the section */
   border-radius: 8px; /* Added border-radius for the section */
   background-color: #f9f9f9; /* Consistent background */
+  transition: none; /* Add this line */
 }
 
 .sliders-and-bits-group {

--- a/src/components/components.css
+++ b/src/components/components.css
@@ -249,9 +249,12 @@ input[type='text']:focus {
 }
 
 .visual-adjuster-section canvas {
-  border: 1px solid black; /* Already in component, but can be centralized here */
-  cursor: crosshair;     /* Already in component */
-  /* margin: 0 auto; */ /* If centered alignment is desired */
+  width: 100%;
+  display: block;
+  border: 1px solid black; /* Consistent with component style */
+  cursor: crosshair;     /* Consistent with component style */
+  touch-action: none;    /* Ensure touch behavior is consistent */
+  /* margin: 0 auto; */ /* Centering might not be needed if width is 100% */
 }
 
 .interactive-controls-section {


### PR DESCRIPTION
This commit implements changes to make the 2D visual adjuster (`VisualValueAdjuster`) component responsive.

Key changes:
- Modified `VisualValueAdjuster.tsx`:
    - Removed fixed WIDTH and HEIGHT constants.
    - Implemented a ResizeObserver to dynamically set the canvas width based on its parent container's width, while maintaining a fixed height of 200px.
    - Updated all drawing and event handling logic to use the dynamic canvas dimensions.
- Modified `App.tsx`:
    - Removed the `flex-basis: 320px` inline style from the div wrapping the `VisualValueAdjuster`. This allows the adjuster to occupy the available space in its flex container.
- Modified `components.css`:
    - Added `width: 100%` and `display: block` to the `canvas` element within the `.visual-adjuster-section` to ensure it spans the full width of its parent.
    - Added `touch-action: none` to the canvas style for better touch interaction on mobile.

These changes ensure that the 2D visual adjuster now expands to the full width of its container and adapts correctly to different screen sizes, including mobile devices, preventing horizontal overflow.